### PR TITLE
fix build of gflags on some compilers

### DIFF
--- a/gflags-2.0/src/gflags.cc
+++ b/gflags-2.0/src/gflags.cc
@@ -348,13 +348,13 @@ string FlagValue::ToString() const {
     case FV_BOOL:
       return VALUE_AS(bool) ? "true" : "false";
     case FV_INT32:
-      snprintf(intbuf, sizeof(intbuf), "%"PRId32, VALUE_AS(int32));
+      snprintf(intbuf, sizeof(intbuf), "%" PRId32, VALUE_AS(int32));
       return intbuf;
     case FV_INT64:
-      snprintf(intbuf, sizeof(intbuf), "%"PRId64, VALUE_AS(int64));
+      snprintf(intbuf, sizeof(intbuf), "%" PRId64, VALUE_AS(int64));
       return intbuf;
     case FV_UINT64:
-      snprintf(intbuf, sizeof(intbuf), "%"PRIu64, VALUE_AS(uint64));
+      snprintf(intbuf, sizeof(intbuf), "%" PRIu64, VALUE_AS(uint64));
       return intbuf;
     case FV_DOUBLE:
       snprintf(intbuf, sizeof(intbuf), "%.17g", VALUE_AS(double));


### PR DESCRIPTION
- C++11 requires a space between literal and identifier

Change-Id: I8ac2f8b55da069189d52d1ea1e0d6e98a1db2b38
Signed-off-by: liuhuahang liuhuahang@xiaomi.com
