### PR TITLE
fix build of gperftools

### DIFF
--- a/gperftools-2.0/src/base/linux_syscall_support.h
+++ b/gperftools-2.0/src/base/linux_syscall_support.h
@@ -250,7 +250,7 @@ struct siginfo;
 struct kernel_old_sigaction {
   union {
     void             (*sa_handler_)(int);
-    void             (*sa_sigaction_)(int, struct siginfo *, void *);
+    void             (*sa_sigaction_)(int, siginfo_t *, void *);
   };
   unsigned long      sa_mask;
   unsigned long      sa_flags;
@@ -287,13 +287,13 @@ struct kernel_sigaction {
   unsigned long      sa_flags;
   union {
     void             (*sa_handler_)(int);
-    void             (*sa_sigaction_)(int, struct siginfo *, void *);
+    void             (*sa_sigaction_)(int, siginfo_t *, void *);
   };
   struct kernel_sigset_t sa_mask;
 #else
   union {
     void             (*sa_handler_)(int);
-    void             (*sa_sigaction_)(int, struct siginfo *, void *);
+    void             (*sa_sigaction_)(int, siginfo_t *, void *);
   };
   unsigned long      sa_flags;
   void               (*sa_restorer)(void);


### PR DESCRIPTION
Use siginfo_t instead of struct siginfo since the former is the POSIX standard and the latter breaks build on some Linux.

http://pubs.opengroup.org/onlinepubs/009695299/basedefs/signal.h.html

Change-Id: I52a8f0da93230f27f7e2ea41f754eb139c5eff3f
Signed-off-by: liuhuahang liuhuahang@xiaomi.com
